### PR TITLE
Fix npm run test

### DIFF
--- a/slow-gc/index.js
+++ b/slow-gc/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
 const restify = require('restify')
 const server = restify.createServer()
 

--- a/sync-io/index.js
+++ b/sync-io/index.js
@@ -20,9 +20,9 @@ process.on('SIGINT', function () {
   server.close()
 })
 
-function sleep (ms){
+function sleep (ms) {
   var now = Date.now()
-  while(Date.now() < now + ms) { 
+  while (Date.now() < now + ms) {
     fs.closeSync(fs.openSync(tmp, 'a'))
-  } 
+  }
 }


### PR DESCRIPTION
The command `npm run test` fails on master:
```console
$ npm run test

> @nearform/clinic-examples@0.1.0 test /home/trivikr/workspace/node-clinic-doctor-examples
> standard | snazzy

standard: Use JavaScript Standard Style (https://standardjs.com)
standard: Run `standard --fix` to automatically fix some problems.

/home/trivikr/workspace/node-clinic-doctor-examples/slow-gc/index.js
  3:7  error  'fs' is assigned a value but never used
  4:7  error  'path' is assigned a value but never used

/home/trivikr/workspace/node-clinic-doctor-examples/sync-io/index.js
  23:20  error  Missing space before opening brace
  25:3   error  Expected space(s) after "while"
  25:33  error  Trailing spaces not allowed
  27:4   error  Trailing spaces not allowed
  28:2   error  Newline required at end of file but not found

✖ 7 problems
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @nearform/clinic-examples@0.1.0 test: `standard | snazzy`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @nearform/clinic-examples@0.1.0 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/trivikr/.npm/_logs/2020-05-19T03_12_18_952Z-debug.log
```

This PR fixes the tests